### PR TITLE
Tags-pets relation

### DIFF
--- a/controllers/petController.js
+++ b/controllers/petController.js
@@ -116,12 +116,6 @@ const createPet = async (req, res) => {
         $push: { tags: limitedTags }
     }, { new: true })
 
-    // add Pet to Tags
-    const petTags = await Tag.updateMany(
-        { _id:  limitedTags   },
-        { $push: { pets: petWithTags._id }}
-    )
-
     res.status(StatusCodes.CREATED).json({ pet:petWithTags })
 }
 
@@ -198,27 +192,12 @@ const updatePet = async (req, res) => {
 
 
     // handle tags relationship
-    const oldTags = pet.tags
     const limitedTags = tags ? tags.slice(0, 5) : null
     pet.tags = limitedTags
 
     await pet.save()
 
-    // remove pet from old tags
-    const removePetFromOldTags = await Tag.updateMany({ pets: {
-        _id: pet._id
-    }}, {
-        $pull: { pets: pet._id }
-    })
-
-    // add pet to new tags
-    const addPetToNewTags = await Tag.updateMany({ _id: limitedTags },
-        {
-            $push: { pets: pet._id }
-        }
-    )
-
-    res.status(StatusCodes.OK).json({ removePetFromOldTags, addPetToNewTags })
+    res.status(StatusCodes.OK).json({})
 
 }
 
@@ -234,12 +213,6 @@ const deletePet = async (req, res) => {
     if (!pet) {
         throw new CustomError.UnauthorizedError('You have no permission')
     }
-
-    const removePetFromTags = await Tag.updateMany({ pets: {
-        _id: pet._id
-    }}, {
-        $pull: { pets: pet._id }
-    })
 
     await pet.deleteOne()
 

--- a/controllers/petController.js
+++ b/controllers/petController.js
@@ -29,6 +29,18 @@ const getRecommendedPets = async (req, res) => {
     res.status(StatusCodes.OK).json({pets})
 }
 
+const removeDuplicateTags = (tags) => {
+    const addedTags = new Set();
+    const dedupedTags = [];
+    for (const tag of tags) {
+        if (!addedTags.has(tag.toString())) {
+            dedupedTags.push(tag);
+            addedTags.add(tag.toString());
+        }
+    }
+    return dedupedTags;
+}
+
 const createPet = async (req, res) => {
     const { type, breed, contract, name, description, age, price, fees, tags, now_available, notes} = req.body
     const userID = req.user.userId
@@ -53,13 +65,13 @@ const createPet = async (req, res) => {
     // - DELETE FILES FROM SERVER AND CLOUDINARY(when not used)
     // - add IMAGES LATER AFTER THE MODEL IS CREATED? Due to validation of other fields.
 
-    const uploadedMainImage = await cloudinary.uploader.upload(
-        mainImage[0].path, 
-        {
-            use_filename: true,
-            folder: 'pets'
-        }
-    )
+    // const uploadedMainImage = await cloudinary.uploader.upload(
+    //     mainImage[0].path, 
+    //     {
+    //         use_filename: true,
+    //         folder: 'pets'
+    //     }
+    // )
     
     // validate images total size
     if(images) {
@@ -77,14 +89,14 @@ const createPet = async (req, res) => {
     // upload images to cloudinary and return links 
     const uploadImages = async () => {
         const images = imagesLocalPaths.map( async (path) => {
-            const image = await cloudinary.uploader.upload(
-                             path, 
-                             {
-                                 use_filename: true,
-                                 folder: 'pets'
-                             }
-            )
-            return image.secure_url
+            // const image = await cloudinary.uploader.upload(
+            //                  path, 
+            //                  {
+            //                      use_filename: true,
+            //                      folder: 'pets'
+            //                  }
+            // )
+            return 'image.secure_url'
         })
         
         const result = await Promise.all(images)
@@ -105,7 +117,7 @@ const createPet = async (req, res) => {
         fees,
         now_available,
         notes,
-        main_image: uploadedMainImage.secure_url,
+        main_image: 'uploadedMainImage.secure_url',
         images: uploadedImages,
         user: ObjectId(userID)
     })
@@ -113,7 +125,7 @@ const createPet = async (req, res) => {
     // Add tags to the Pet and limit max 5
     const limitedTags = tags ? tags.slice(0, 5) : null
     const petWithTags = await Pet.findByIdAndUpdate(pet._id, {
-        $push: { tags: limitedTags }
+        $push: { tags: removeDuplicateTags(limitedTags) }
     }, { new: true })
 
     res.status(StatusCodes.CREATED).json({ pet:petWithTags })
@@ -193,7 +205,7 @@ const updatePet = async (req, res) => {
 
     // handle tags relationship
     const limitedTags = tags ? tags.slice(0, 5) : null
-    pet.tags = limitedTags
+    pet.tags = removeDuplicateTags(limitedTags)
 
     await pet.save()
 

--- a/controllers/petUploadImagesController.js
+++ b/controllers/petUploadImagesController.js
@@ -2,6 +2,7 @@ require('dotenv').config()
 const multer  = require('multer');
 const cloudinary = require('cloudinary').v2;
 const { CloudinaryStorage } = require('multer-storage-cloudinary');
+const CustomError = require('../errors');
 
 
 cloudinary.config({ 

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -22,10 +22,6 @@ const tagSchema = new Schema({
         index: true,
         slug_padding_size: 2
     },
-    pets:[{
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Pet',
-    }]
 })
 
 module.exports = mongoose.model('Tag', tagSchema)


### PR DESCRIPTION
# Removed the relation on the tag side

## How relations work in Mongoose

Under the hood, the relation data is just an `ObjectId` (or an array of `ObjectId`s, like in your case), but Mongoose allows you to call `populate()` to automatically fetch related documents.

My point is that having this array of `ObjectId`s on one side only is still perfectly valid, although you won't be able to use `populate()` on the tag side.

## Why you might want to have your relation on one side only

The `tags` array on the `Pet` and the `pets` array on the `Tag` basically describe the same information - they connect pets to tags. These arrays can be derived from each other, the code which does it is in `controllers/tagController.js`, `populatePets` function.

If you store the relation on both sides, you store the same data twice. The problem is not about disk space, but about the fact that every time you update the relation, you have to update both sides. This increases duplication in your code and makes it more complex. The worst part is that if you update one side and don't update the other (either because there are problems with the database or you forget to do it in the code), these arrays will contain different data, which is an invalid state. So, it is an opportunity to create bugs.

The solution is to create a _single source of truth_, i. e. to avoid storing data in multiple different places and formats. In our case, we do it by only storing the relation on one side, and deriving (calculating) the `pets` array on the `Tag` rather than putting it into the database. Of course, this comes at a cost of a slight performance decrease, but it is often insignificant compared to the issues you may have in development.

# Added logic to prevent inserting duplicate tags

I added code which deduplicates tags on pets (and, since pets on tags are calculated, it also dedupes pets on tags). It is done by using a `Set` (because the `Set#has` method doesn't have to loop over every item, so its performance doesn't depend on the set size, unlike `Array#includes`).