### PR TITLE
CRUD enhancements in petController and tagController

### DIFF
--- a/controllers/petController.js
+++ b/controllers/petController.js
@@ -149,14 +149,14 @@ const getSinglePet = async (req, res) => {
 
 const updatePet = async (req, res) => {
     const { type, breed, contract, name, description, age, price, fees, tags, notes, now_available } = req.body
-    const { slug } = req.params
+    const { id } = req.params
     const userID = req.user.userId
 
     if (breed) {
         checkAllowedBreeds({ type, breed, catBreeds, dogBreeds, otherBreeds });
     }
 
-    const pet = await Pet.findOneAndUpdate({ slug, user: userID }, {
+    const pet = await Pet.findOneAndUpdate({ _id: id, user: userID }, {
         type,
         breed,
         contract,
@@ -188,10 +188,10 @@ const updatePet = async (req, res) => {
 }
 
 const deletePet = async (req, res) => {
-    const { slug } = req.params
+    const { id } = req.params
     const userID = req.user.userId
 
-    const pet = await Pet.findOne({ slug, user: userID }).populate({
+    const pet = await Pet.findOne({ _id: id, user: userID }).populate({
         path: 'tags',
         select: 'name slug _id'
     })

--- a/controllers/petController.js
+++ b/controllers/petController.js
@@ -99,8 +99,10 @@ const createPet = async (req, res) => {
         return result
     }
 
-   const uploadedImages = await uploadImages()
+    const uploadedImages = await uploadImages()
 
+
+    const limitedTags = tags ? removeDuplicateTags(tags.split(',').slice(0, 5)) : []
     // Create a Pet instance 
     const pet = await Pet.create({
         type,
@@ -115,16 +117,11 @@ const createPet = async (req, res) => {
         notes,
         main_image: 'uploadedMainImage.secure_url',
         images: uploadedImages,
-        user: ObjectId(userID)
+        user: ObjectId(userID),
+        tags: limitedTags,
     })
 
-    // Add tags to the Pet and limit max 5
-    const limitedTags = tags ? tags.split(',').slice(0, 5) : []
-    const petWithTags = await Pet.findByIdAndUpdate(pet._id, {
-        $push: { tags: removeDuplicateTags(limitedTags) }
-    }, { new: true })
-
-    res.status(StatusCodes.CREATED).json({ pet:petWithTags })
+    res.status(StatusCodes.CREATED).json({ pet })
 }
 
 

--- a/controllers/petController.js
+++ b/controllers/petController.js
@@ -9,11 +9,7 @@ const { checkAllowedBreeds } = require('../utils')
 const { catBreeds, dogBreeds, otherBreeds } = require('../constants')
 
 
-// TODO
-
-// ADD Tag only ONCE to Pet ???? Pre save hook?
-// ADD Tag can have Pet once ???? Pre save hook?
-// DELETE IMAGE WHEN THEY ARE NOT USED -> SERVER, CLOUDINARY
+// TODO: DELETE IMAGE WHEN THEY ARE NOT USED -> SERVER, CLOUDINARY
 
 
 const getAllPets = async (req, res) => {

--- a/controllers/petController.js
+++ b/controllers/petController.js
@@ -119,7 +119,7 @@ const createPet = async (req, res) => {
     })
 
     // Add tags to the Pet and limit max 5
-    const limitedTags = tags ? tags.slice(0, 5) : null
+    const limitedTags = tags ? tags.split(',').slice(0, 5) : []
     const petWithTags = await Pet.findByIdAndUpdate(pet._id, {
         $push: { tags: removeDuplicateTags(limitedTags) }
     }, { new: true })

--- a/controllers/tagController.js
+++ b/controllers/tagController.js
@@ -44,9 +44,9 @@ const createTag = async (req, res) => {
 }
 
 const getSingleTag = async (req, res) => {
-    const { slug } = req.params
+    const { id } = req.params
 
-    const tag = await Tag.findOne({ slug })
+    const tag = await Tag.findById(id)
     populatePets([tag]);
 
     if (!tag) {
@@ -57,9 +57,9 @@ const getSingleTag = async (req, res) => {
 }
 
 const updateTag = async (req, res) => {
-    const { slug } = req.params
+    const { id } = req.params
  
-    const tag = await Tag.findOne({ slug })
+    const tag = await Tag.findById(id)
 
     if (!tag) {
         throw new CustomError.NotFoundError('Tag was not found')
@@ -69,21 +69,13 @@ const updateTag = async (req, res) => {
 }
 
 const deleteTag = async (req, res) => {
+    const { id } = req.params
 
-    const { slug } = req.params
-
-    const tag = await Tag.findOne({ slug })
+    const tag = await Tag.findOne(id)
 
     if (!tag) {
         throw new CustomError.NotFoundError('Tag was not found')
     }
-
-    // delete tag from pet
-    const deleteTagFromPet = await Pet.updateMany({ tags: tag._id }, {
-        $pull: { 
-            tags: tag._id
-        }
-    })
 
     await tag.deleteOne()
 

--- a/routes/petRoutes.js
+++ b/routes/petRoutes.js
@@ -25,6 +25,9 @@ router
 router
     .route('/:slug')
     .get(getSinglePet)
+
+router
+    .route('/:id')
     .patch([authenticateUser], updatePet)
     .delete([authenticateUser], deletePet)
 //other routes add authorize permission - add policy...

--- a/routes/tagRoutes.js
+++ b/routes/tagRoutes.js
@@ -20,7 +20,7 @@ router
     .post([authenticateUser, authorizePermissions('admin')], createTag)
 
 router
-    .route('/:slug')
+    .route('/:id')
     .get(getSingleTag)
     .patch([authenticateUser, authorizePermissions('admin')], updateTag)
     .delete([authenticateUser, authorizePermissions('admin')], deleteTag)


### PR DESCRIPTION
Here's the explanation of the changes made:

# Most of the operations are now performed by ID rather than by slug

The whole idea of having IDs is to have a field which doesn't change over the lifetime of the document, so that when you update the document, it doesn't break all the relations. However, it is possible to change the slug by changing the name. So, if such an edit happens while another user is browsing, they might get a 404 error, or even update a completely different pet/tag than they intended to update.

In some cases using the slug is unavoidable, like for example `getSinglePet`. Here, the frontend simply does not know the ID, so the pet must be queried by the `slug`.

# Cleaner update logic in the `petController`

Now there is no need to set every property one by one, and `tags` are updated in the same database query.

# Fixed handling of tags in `createPet`

Since `multipart/form-data` has no support for arrays, `tags` comes in as a string, and gets `slice()`d into 5 characters (because strings have a `slice` method, just like arrays). This causes errors.

Now the logic is to split the `tags` by commas to make it an array and make the `removeDuplicateTags(tags.slice(0, 5))` part behave as expected.

# Tags are now inserted in the same database query

Previously, tags were inserted in separate database queries when updating or creating pets. Now, in the update (as already mentioned) and create methods tags are inserted in the same database query.