### PR TITLE
Fix sanitization: call next() in the hook

### DIFF
--- a/models/Pet.js
+++ b/models/Pet.js
@@ -119,6 +119,8 @@ petSchema.pre('save', function preSavePet(next) {
     if (this.description) {
         this.description = sanitizeHtml(this.description);
     }
+
+    next()
 });
 
 module.exports = mongoose.model('Pet', petSchema)


### PR DESCRIPTION
It turns out that Mongoose hooks are callback-based, so it is necessary to call a callback when your synchronous and asynchronous actions inside the hook are complete. Otherwise Mongoose will wait for the completion forever.