### PR TITLE
Add search

### DIFF
--- a/controllers/petController.js
+++ b/controllers/petController.js
@@ -15,7 +15,7 @@ const { catBreeds, dogBreeds, otherBreeds, allowedTypes, checkAllowedBreedsQuery
 
 const getAllPets = async (req, res) => {
     const userID = req.user?.userId ? req.user.userId  : null
-    const { type, breed, contract, now_available, featured, age, skip, limit } = req.query
+    const { type, breed, contract, now_available, featured, age, search, skip, limit } = req.query
 
     const queryObject = {}
     if(type && allowedTypes.includes(type)) {
@@ -44,16 +44,49 @@ const getAllPets = async (req, res) => {
         favoritePetIDs.add(favoritePet.pet.toString())
     }
 
-    const populateWithData = [{ path: 'tags', select: 'name slug _id'}, {path: 'user', select: '_id username'}]
-
     // get pets
-    const pets = await Pet.find(queryObject).skip(skip).limit(limit).populate(populateWithData)
+    const pets = await Pet.aggregate([
+        ...(search ? [{
+            $search: {
+                index: 'default',
+                phrase: {
+                    query: search,
+                    path: ['name', 'description', 'notes'],
+                    // slop: 1,
+                },
+            },
+        }] : []),
+        { $match: queryObject },
+        { $skip: skip ?? 0 },
+        { $limit: Number(limit ?? 10) },
+        {
+            $lookup: {
+                from: 'users',
+                localField: 'user',
+                foreignField: '_id',
+                as: 'user',
+            },
+        },
+        {
+            $lookup: {
+                from: 'tags',
+                localField: 'tags',
+                foreignField: '_id',
+                as: 'tags',
+            },
+        },
+    ]);
 
 
     const petsWithFavorite = pets.map((pet) => {
+        const [{ _id, username }] = pet.user;
+        const tags = pet.tags.map(({ _id, slug, name }) => ({ _id, slug, name }));
+
         return {
-            ...pet.toJSON(),
-            isFavorite: favoritePetIDs.has(pet.id.toString())
+            ...pet,
+            user: { _id, username },
+            tags,
+            isFavorite: favoritePetIDs.has(pet._id.toString())
         }
     })
 
@@ -271,7 +304,7 @@ const updatePet = async (req, res) => {
         }, 
         images: uploadedImages&&uploadedImages,
         
-        tags: tags && removeDuplicateTags(tags.slice(0, 5)),
+        tags: tags && removeDuplicateTags(tags.split(',').slice(0, 5)),
     }, {
         new: true,
         populate: {

--- a/controllers/petController.js
+++ b/controllers/petController.js
@@ -60,12 +60,6 @@ const getAllPets = async (req, res) => {
     res.status(StatusCodes.OK).json({ pets: petsWithFavorite })
 }
 
-const getRecommendedPets = async (req, res) => {
-    // for Main page and advertisments 
-    const pets = await Pet.find({}).populate([{ path: 'tags', select: 'name slug _id'}, {path: 'user', select: '_id username'}]).limit(5)
-    res.status(StatusCodes.OK).json({pets})
-}
-
 const removeDuplicateTags = (tags) => {
     const addedTags = new Set();
     const dedupedTags = [];
@@ -218,7 +212,7 @@ const updatePet = async (req, res) => {
 
 
     // validate MainImage 
-    if (mainImage&&mainImage[0].size >= process.env.PET_MAIN_IMAGE_MAX_SIZE) {
+    if (mainImage && mainImage[0].size >= process.env.PET_MAIN_IMAGE_MAX_SIZE) {
         throw new CustomError.BadRequestError('Allowed capacity for main_image is 5mb')
     }
     let uploadedMainImage
@@ -331,5 +325,4 @@ module.exports = {
     getSinglePet,
     updatePet,
     deletePet,
-    getRecommendedPets,
 }

--- a/routes/petRoutes.js
+++ b/routes/petRoutes.js
@@ -5,9 +5,8 @@ const { imageConfig } = require('../controllers/petUploadImagesController')
 
 const {
     authenticateUser,
-    authorizePermissions,
     publicRouteAuthenticateUser,
-  } = require('../middleware/authentication');
+} = require('../middleware/authentication');
 
 const {
     getAllPets,
@@ -15,7 +14,6 @@ const {
     getSinglePet,
     updatePet,
     deletePet,
-    getRecommendedPets
 } = require('../controllers/petController')
 
 router
@@ -32,9 +30,5 @@ router
     .patch([authenticateUser, imageConfig], updatePet)
     .delete([authenticateUser], deletePet)
 //other routes add authorize permission - add policy...
-
-router
-    .route('/recommended/main')
-    .get(getRecommendedPets)
 
 module.exports = router


### PR DESCRIPTION
# Changes

## Removed `getRecommendedPets`

The `getAllPets` route already covers the functionality of `getRecommendedPets`, including the 5-item limit. In addition, the frontend can easily make queries for recommended pets with search and filtering to the `getAllPets` route, which is not possible with the old `getRecommendedPets`.

## Added Atlas Search

Atlas Search works in an aggregation pipeline, so I replaced the ordinary `.find()` query we used to have. When configuring the database connection, please make sure that the database name in the URL matches the database name in the index settings.

Here's the URL Atlas gives you:
```
mongodb+srv://mastermindlegion:<password>@nodeproject.oky9y.mongodb.net/?retryWrites=true&w=majority
```
Here there is no database name specified. The default database name is `test`.

In order to specify another database name, please change the URL like this:
```
mongodb+srv://mastermindlegion:<password>@nodeproject.oky9y.mongodb.net/PETS_FINDER?retryWrites=true&w=majority
```

I will set up an index on the `PETS_FINDER` database.

# Explanation of the aggregation pipeline:
1. `$search` - a special stage added by Atlas Search. Here are some useful docs about it:
https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/
https://www.mongodb.com/docs/atlas/atlas-search/phrase/#definition
1. `$skip` and `$limit` - self explanatory
1. `$lookup` - does a similar thing to `.populate()` (except that `.populate()` is a Mongoose-only thing, while `$lookup` is built into MongoDB). Here's the documentation: https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#definition

## Other related changes
1. Removed `.toJSON()`, because the result of an aggregation is untouched by Mongoose, it's a plain object
2. The fields of `tags` and `user` are now selected in JavaScript. It is possible to do it in MongoDB, but I don't want to overwhelm you even more. If you're interested in this topic, please let me know.